### PR TITLE
chore(deps): bump actions/checkout from 4 to 5

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -16,7 +16,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         


### PR DESCRIPTION
Bumps actions/checkout from 4 to 5. Updated for latest security and performance improvements.